### PR TITLE
Ensure we turn off LWF in the by-wind-speed extrapolation for CFD.ML

### DIFF
--- a/Examples/WebApi/CFDMLv2/cfdml_v2_calculator.ipynb
+++ b/Examples/WebApi/CFDMLv2/cfdml_v2_calculator.ipynb
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,9 +201,6 @@
     "CFDML_VERSION = \"2.6.0\"\n",
     "BLOCKAGE_APPLICATION_METHOD = \"OnWindSpeed\" # OnWindSpeed / OnEnergy\n",
     "NUMBER_OF_DIRECTION_STEPS = 180\n",
-    "\n",
-    "# For WAKE_MODEL_CHOICE = CFD.ML  we currently reccomend not applying any large wind farm correction in by-wind-speed extrapolation of CFD.ML results.\n",
-    "EXTRAPOLATE_CFDML_USING_LARGE_WIND_FARM_CORRECTION = False # True/False\n",
     "\n",
     "# However, should you wish to use this notebook with a WAKE_MODEL_CHOICE of EddyViscosity, \n",
     "# you should define your large wind farm correction settings \n",
@@ -3004,7 +3001,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.9.18"
   },
   "metadata": {
    "interpreter": {

--- a/Examples/WebApi/CFDMLv2/script_lib/input_json_prep.py
+++ b/Examples/WebApi/CFDMLv2/script_lib/input_json_prep.py
@@ -177,6 +177,7 @@ def set_model_settings(input_json, wake_model_choice, blockage_model_choice,
         extrapolation_model = wake_models["CFDML"]["model_settings"]["extrapolationModel"]
         if extrapolation_model != "BasicFlat":
             input_json["energyEfficienciesSettings"]["wakeModel"][wake_models[extrapolation_model]["model_key"]] = wake_models[extrapolation_model]["model_settings"]
+        input_json["energyEfficienciesSettings"]["wakeModel"]["eddyViscosity"]["useLargeWindFarmModel"] = False
     
     input_json["energyEfficienciesSettings"]["blockageModel"]["blockageModelType"] = blockage_model_choice
     input_json["energyEfficienciesSettings"]["blockageModel"][blockage_models[blockage_model_choice]["model_key"]] = blockage_models[blockage_model_choice]["model_settings"]


### PR DESCRIPTION
A user-input setting in the CFD.ML notebook was not being respected.
We took the decision to never use LWF in the extrapolation. So the notebook should follow that decision.